### PR TITLE
Use xdg-open for Linux users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,20 @@
 # Zoom CLI
 
-Do you have multiple recurring Zoom meetings? Are you sick of having to open a calendar invite, find the meeting URL, then open it in your browser? This tool is for you.
-
 `zoom` is a command line tool that allows users to store, access, and launch Zoom meetings on the fly.
 
-It is written in Python and available to install via Homebrew. A previous version of this tool was written in C# with the .NET Core SDK.
+It is written in Python and available to install via Homebrew.
+
+## Installation Instructions
+
+### Mac/Linux Users
+
+1. Download and install Homebrew: [https://brew.sh](https://brew.sh).
+2. `brew tap tmonfre/homebrew-tmonfre`
+3. `brew install zoom`
+
+### PC Users
+
+This package is currently not yet available on Scoop. Please follow the [developer instructions](#developer-instructions) below in the meantime.
 
 ## Usage
 
@@ -32,18 +42,6 @@ Below are the available commands. If an option/flag listed below is ommitted, yo
 - `zoom rm [name]` to delete a stored meeting
 
 - `zoom ls` to see all stored meetings
-
-## Installation Instructions
-
-### Mac Users
-
-1. Download and install Homebrew: [https://brew.sh](https://brew.sh).
-2. `brew tap tmonfre/homebrew-tmonfre`
-3. `brew install zoom`
-
-### PC Users
-
-This package is currently not yet available on Scoop. Please follow the developer instructions below in the meantime.
 
 ## Developer Instructions
 

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -1,5 +1,6 @@
 import os
 import json
+import subprocess
 
 __version__ = "1.1.3"
 
@@ -42,10 +43,16 @@ def write_to_meeting_file(contents):
     with open(SAVE_FILE_PATH, "w") as file:
         file.write(dict_to_json_string(contents))
 
+def is_command_available(command):
+    s = subprocess.Popen("command -v {}".format(command), shell=True, stdout=subprocess.PIPE)
+    output = s.stdout.read().decode("utf-8")
+    return len(output) > 0
+
 def launch_zoommtg(id, password):
     url = "zoommtg://zoom.us/join?confno=" + id
 
     if password:
         url += "&pwd=" + password
 
-    os.system('open "{}"'.format(url))
+    command = "open" if is_command_available("open") else "xdg-open"
+    os.system('{} "{}"'.format(command, url))

--- a/zoom_cli/utils.py
+++ b/zoom_cli/utils.py
@@ -2,7 +2,7 @@ import os
 import json
 import subprocess
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 ZOOM_CLI_DIR = os.path.expanduser("~/.zoom-cli")
 SAVE_FILE_PATH = "{}/meetings.json".format(ZOOM_CLI_DIR)


### PR DESCRIPTION
- Checks if `open` command is available before running
- Uses `xdg-open` if `open` not available
- Also made minor updates to README and bumped to v1.1.4

Closes #1 